### PR TITLE
Correctly set state to OFF w/o Internet connection

### DIFF
--- a/src/accessory.js
+++ b/src/accessory.js
@@ -591,8 +591,8 @@ class Fritz_Box {
                     accessory.context.lastSwitchState = true;
                     callback(null, true);
                   } else {
-                    accessory.context.lastSwitchState = true;
-                    callback(null, true);
+                    accessory.context.lastSwitchState = false;
+                    callback(null, false);
                   }
                 } else {
                   self.logger.errorinfo(accessory.displayName + 'An error occured by getting device state!');


### PR DESCRIPTION
Fix for issue #13 - when Internet is not connected the HomeKit switch should be in state OFF.