### PR TITLE
Update Supported.md

### DIFF
--- a/docs/Supported.md
+++ b/docs/Supported.md
@@ -13,6 +13,7 @@
 - [x] Fritz!Box 7430
 - [x] Fritz!Box 7390 WLAN
 - [x] Fritz!Box 7360 WLAN
+- [x] Fritz!Box 6660 Cable
 - [x] Fritz!Box 6591 Cable
 - [x] Fritz!Box 6590 Cable
 - [x] Fritz!Box 6490 Cable
@@ -28,6 +29,7 @@
 - [x] Fritz!DECT 500
 - [x] Fritz!DECT 404
 - [x] Fritz!DECT 301
+- [x] Fritz!DECT 210
 - [x] Fritz!DECT 200
 - [x] HAN-FUN Contact sensor
 


### PR DESCRIPTION
I set up the project with my Fritz!Box 6660 Cable on Fritz!OS 7.23 and a Fritz!DECT 210 outlet.

Not sure how much testing you expect to mark a device as supported, but I'd be happy to run through a few scenarios if that helps.

Side note: The setup was without issue, but I would have appreciated a note that you need to scroll down to see the settings to enable TR064 and that a restart of the `homebridge` server is necessary to see the new devices. But I guess those are beginner mistakes, so feel free to ignore if you don't see a need to change it.